### PR TITLE
Fixed Light/Dark Reader Mode and Added Global Theme Context

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,7 +4,6 @@ import Home from "./pages/home";
 import Footer from "./utlis/footer";
 import Lottie from "react-lottie";
 import * as animationData from "./animations/animations.json";
-import ThemeToggle from './utlis/themetoggler'
 
 const App = () => {
   const [youtubeID] = useState("eGSUvfVt3k4");

--- a/src/contexts/ThemeContext.jsx
+++ b/src/contexts/ThemeContext.jsx
@@ -1,0 +1,30 @@
+import { createContext, useState, useContext, useEffect } from "react";
+
+const ThemeContext = createContext();
+
+export const ThemeProvider = ({ children }) => {
+  const [theme, setTheme] = useState(()=>{
+    return localStorage.getItem("theme") || "light";
+  }); // Default theme
+
+  const toggleTheme = () => {
+    setTheme((prevTheme) => (prevTheme === "light" ? "dark" : "light"));
+  };  
+
+  useEffect(() => {
+    if (theme === "dark") {
+      document.body.classList.add("dark");
+    } else {
+      document.body.classList.remove("dark");
+    }
+    localStorage.setItem("theme", theme);
+  }, [theme]);
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+};
+
+export const useTheme = () => useContext(ThemeContext);

--- a/src/index.js
+++ b/src/index.js
@@ -3,11 +3,14 @@ import ReactDOM from 'react-dom/client';
 import './index.css';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
+import { ThemeProvider } from "./contexts/ThemeContext";
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <React.StrictMode>
-    <App />
+    <ThemeProvider>
+      <App />
+    </ThemeProvider>
   </React.StrictMode>
 );
 

--- a/src/pages/home.jsx
+++ b/src/pages/home.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from "react";
-import { ReactReader } from "react-reader";
+import { ReactReader, ReactReaderStyle } from "react-reader";
 import close from "../images/close.png";
 
 import percyjackson from "../books/percyjackson.epub"
@@ -7,8 +7,10 @@ import percyjackson from "../books/percyjackson.epub"
 import gameofthrones from "../books/gameofthrones.epub"
 import harrypotter from "../books/harrypotter.epub"
 import mahabharat from "../books/mahabharat.epub"
+import { useTheme } from "../contexts/ThemeContext";
 
 const Home = () => {
+  const { theme } = useTheme();
   const [location, setLocation] = useState(0);
   const [selections, setSelections] = useState([]);
   const [rendition, setRendition] = useState(undefined);
@@ -34,6 +36,22 @@ const Home = () => {
     gameofthrones,
     percyjackson,
   ];
+
+  function updateTheme(rendition, theme) {
+    const themes = rendition.themes
+    switch (theme) {
+      case 'dark': {
+        themes.override('color', '#fff')
+        themes.override('background', '#000')
+        break
+      }
+      default: {
+        themes.override('color', '#000')
+        themes.override('background', '#fff')
+        break
+      }
+    }
+  }
   
   useEffect(() => {
     if (rendition) {
@@ -59,6 +77,12 @@ const Home = () => {
       };
     }
   }, [setSelections, rendition]);
+
+  useEffect(() => {
+    if (rendition) {
+      updateTheme(rendition, theme)
+    }
+  }, [theme])
   
   useEffect(() => {
     if (send && selections.length > 0) {
@@ -134,7 +158,9 @@ const Home = () => {
             allowPopups: true, // Adds `allow-popups` to sandbox-attribute
             allowScriptedContent: true, // Adds `allow-scripts` to sandbox-attribute
           }}
+          readerStyles={theme === 'dark' ? darkReaderTheme : lightReaderTheme}
           getRendition={(_rendition) => {
+            updateTheme(_rendition, theme)
             setRendition(_rendition);
           }}
         />
@@ -310,5 +336,51 @@ const Home = () => {
     </div>
   );
 };
+
+const lightReaderTheme = {
+  ...ReactReaderStyle,
+  readerArea: {
+    ...ReactReaderStyle.readerArea,
+    transition: undefined,
+  },
+}
+
+
+const darkReaderTheme = {
+  ...ReactReaderStyle,
+  arrow: {
+    ...ReactReaderStyle.arrow,
+    color: 'white',
+  },
+  arrowHover: {
+    ...ReactReaderStyle.arrowHover,
+    color: '#ccc',
+  },
+  readerArea: {
+    ...ReactReaderStyle.readerArea,
+    backgroundColor: '#000',
+    transition: undefined,
+  },
+  titleArea: {
+    ...ReactReaderStyle.titleArea,
+    color: '#ccc',
+  },
+  tocArea: {
+    ...ReactReaderStyle.tocArea,
+    background: '#111',
+  },
+  tocButtonExpanded: {
+    ...ReactReaderStyle.tocButtonExpanded,
+    background: '#222',
+  },
+  tocButtonBar: {
+    ...ReactReaderStyle.tocButtonBar,
+    background: '#fff',
+  },
+  tocButton: {
+    ...ReactReaderStyle.tocButton,
+    color: 'white',
+  },
+}
 
 export default Home;

--- a/src/utlis/themetoggler.jsx
+++ b/src/utlis/themetoggler.jsx
@@ -1,32 +1,20 @@
-import { useState, useEffect } from "react";
+import { useTheme } from "../contexts/ThemeContext";
 
 const ThemeToggle = () => {
-  const [darkMode, setDarkMode] = useState(
-    localStorage.getItem("theme") === "dark"
-  );
-
-  useEffect(() => {
-    if (darkMode) {
-      document.documentElement.classList.add("dark");
-      localStorage.setItem("theme", "dark");
-    } else {
-      document.documentElement.classList.remove("dark");
-      localStorage.setItem("theme", "light");
-    }
-  }, [darkMode]);
+  const { theme, toggleTheme } = useTheme();
 
   return (
     <button
-      onClick={() => setDarkMode(!darkMode)}
+      onClick={() => toggleTheme()}
       className="relative w-20 h-8 flex items-center rounded-full bg-yellow-300 dark:bg-blue-800 p-1 transition"
     >
       <div
         className={`w-6 h-6 bg-white rounded-full shadow-md transform transition ${
-          darkMode ? "translate-x-10" : "translate-x-0"
+          (theme==="dark") ? "translate-x-10" : "translate-x-0"
         }`}
       />
       <span className="absolute left-2 text-xs font-bold text-white">
-        {darkMode ? "🌙" : "☀️"}
+        {(theme==="dark") ? "🌙" : "☀️"}
       </span>
     </button>
   );


### PR DESCRIPTION
Resolves #22 .

## Description
- Added Dark and Light Mode to the React Reader using React Reader Styles
- Extra: Added a global theme context so that other things which doesn't change with theme automatically can access the theme variable and change according to it (In this case, the React Reader)

## Live Demo (if any)
![image](https://github.com/user-attachments/assets/10724d24-7f03-435a-80d7-fa03070ff08c)
![image](https://github.com/user-attachments/assets/28cc82dd-22f8-44a7-84b3-3ca8e065fda4)


## Checkout
- [x] I have read all the contributor guidelines for the repo.
